### PR TITLE
Update app-template for media

### DIFF
--- a/kubernetes/home/apps/media/jackett/release.yaml
+++ b/kubernetes/home/apps/media/jackett/release.yaml
@@ -14,63 +14,87 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-      version: 1.5.0 # {"$imagepolicy": "flux-system:app-template:tag"}
+      version: 2.0.3 # {"$imagepolicy": "flux-system:app-template:tag"}
   values:
-    image:
-      repository: docker.io/spritsail/jackett
-      tag: "0.21.976" # {"$imagepolicy": "flux-system:jackett:tag"}
-      pullPolicy: IfNotPresent
-    env:
-      SUID: 568
-      SGID: 568
-    probes:
-      liveness:
-        custom: true
-        spec:
-          exec:
-            command:
-              - wget
-              - -qO
-              - /dev/null
-              - http://localhost:9117/torznab/all
-          initialDelaySeconds: 10
-          timeoutSeconds: 5
-    securityContext:
-      capabilities:
-        drop:
-          - ALL
-        add:
-          - SETUID
-          - SETGID
-    service:
+    env: {} # Necessary for the generic TZ patch to not fail
+    controllers:
       main:
-        ports:
-          http:
-            port: 9117
+        pod:
+          securityContext:
+            fsGroup: 997
+            fsGroupChangePolicy: "OnRootMismatch"
+        containers:
+          main:
+            env:
+              SGID: 997
+              TZ: ${TZ}
+            image:
+              repository: docker.io/spritsail/jackett
+              tag: "0.21.976" # {"$imagepolicy": "flux-system:jackett:tag"}
+              pullPolicy: IfNotPresent
+            nameOverride: jackett
+            ports:
+              - containerPort: 9117
+                name: http
+                protocol: TCP
+            probes:
+              liveness:
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - wget
+                      - -qO
+                      - /dev/null
+                      - http://localhost:9117/torznab/all
+                  initialDelaySeconds: 10
+                  timeoutSeconds: 5
+            resources:
+              limits:
+                memory: 400Mi
+              requests:
+                memory: 200Mi
+                cpu: 10m
+            securityContext:
+              capabilities:
+                drop:
+                  - ALL
+                add:
+                  - SETUID
+                  - SETGID
+              readOnlyRootFilesystem: true
+
     ingress:
       main:
-        enabled: true
         annotations:
           hajimari.io/icon: mdi:movie-search
           traefik.ingress.kubernetes.io/router.entrypoints: websecure
           traefik.ingress.kubernetes.io/router.tls: "true"
-        labels:
-          probe: enabled
+        enabled: true
         hosts:
           - host: jackett.kubi.${DOMAIN_LOCAL}
             paths:
               - path: /
                 pathType: Prefix
+                service:
+                  name: main
+        labels:
+          probe: enabled
+
     persistence:
       config:
         enabled: true
         mountPath: /config
-        storageClass: longhorn
-        size: 1Gi
         retain: true
-    resources:
-      limits:
-        memory: 400Mi
-      requests:
-        memory: 200Mi
-        cpu: 10m
+        size: 1Gi
+        storageClass: longhorn
+      tmp:
+        enabled: true
+        mountPath: /tmp
+        type: emptyDir
+
+    service:
+      main:
+        ports:
+          http:
+            port: 9117

--- a/kubernetes/home/apps/media/jellyfin/release.yaml
+++ b/kubernetes/home/apps/media/jellyfin/release.yaml
@@ -14,105 +14,130 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-      version: 1.5.0  # {"$imagepolicy": "flux-system:app-template:tag"}
+      version: 2.0.3  # {"$imagepolicy": "flux-system:app-template:tag"}
   values:
     env: {}  # Necessary for the generic TZ patch to not fail
-    image:
-      repository: docker.io/jellyfin/jellyfin
-      tag: 10.8.5   # {"$imagepolicy": "flux-system:jellyfin:tag"}
-      pullPolicy: IfNotPresent
-    probes:
-      liveness:
-        custom: true
-        spec:
-          exec:
-            command:
-              - /bin/bash
-              - '-c'
-              - 'curl -Lk -fsS http://127.0.0.1:8096/health || exit 1'
-          initialDelaySeconds: 10
-          periodSeconds: 30
-          timeoutSeconds: 30
-      readiness:
-        type: HTTP
-        path: /
-    securityContext:
-      capabilities:
-        drop:
-          - ALL
+    controllers:
+      main:
+        containers:
+          main:
+            env:
+              TZ: ${TZ}
+            image:
+              repository: docker.io/jellyfin/jellyfin
+              tag: 10.8.5   # {"$imagepolicy": "flux-system:jellyfin:tag"}
+              pullPolicy: IfNotPresent
+            nameOverride: jellyfin
+            ports:
+              - containerPort: 8096
+                name: http
+                protocol: TCP
+              - containerPort: 8920
+                name: https
+                protocol: TCP
+            probes:
+              liveness:
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - /bin/bash
+                      - '-c'
+                      - 'curl -Lk -fsS http://127.0.0.1:8096/health || exit 1'
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 30
+              readiness:
+                type: HTTP
+                path: /
+            resources:
+              limits:
+                gpu.intel.com/i915: 1
+                memory: 6Gi
+              requests:
+                memory: 2Gi
+                cpu: 1
+            securityContext:
+              capabilities:
+                drop:
+                  - ALL
+
+    ingress:
+      main:
+        annotations:
+          hajimari.io/icon: mdi:emby
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+          traefik.ingress.kubernetes.io/router.tls: "true"
+        enabled: true
+        hosts:
+          - host: jelly.kubi.${DOMAIN_LOCAL}
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  name: main
+        labels:
+          probe: enabled
+      public:
+        annotations:
+          hajimari.io/enable: "false"
+          traefik.ingress.kubernetes.io/router.entrypoints: webpublic
+          traefik.ingress.kubernetes.io/router.tls: "true"
+        enabled: true
+        hosts:
+          - host: play.${DOMAIN_PUBLIC}
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  name: main
+        labels:
+          probe: enabled
+
+    persistence:
+      config:
+        enabled: true
+        retain: true
+        size: 10Gi
+        storageClass: longhorn
+      media:
+        enabled: true
+        globalMounts:
+          - path: /mnt/tv
+            subPath: Shows/Complete
+          - path: /mnt/movies
+            subPath: Movies/Complete
+        path: /tank/Media
+        server: nas
+        type: nfs
+      certificate:
+        enabled: true
+        globalMounts:
+          - path: /etc/ssl/private
+            readOnly: true
+        name: letsencrypt-jellyfin
+        type: secret
+      cache:
+        enabled: true
+        mountPath: /cache
+        type: emptyDir
+
     service:
       main:
         ports:
           http:
             port: 8096
       https:
+        annotations:
+          metallb.universe.tf/allow-shared-ip: "metallb-shared-ip"
+        controller: main
+        enabled: true
+        externalIPs:
+          - ${METALLB_ADDRESS}
         ports:
           https:
             port: 8920
-        annotations:
-          metallb.universe.tf/allow-shared-ip: "metallb-shared-ip"
         type: LoadBalancer
-        externalIPs:
-          - ${METALLB_ADDRESS}
+
     serviceAccount:
       create: true
-    ingress:
-      main:
-        enabled: true
-        annotations:
-          hajimari.io/icon: mdi:emby
-          traefik.ingress.kubernetes.io/router.entrypoints: websecure
-          traefik.ingress.kubernetes.io/router.tls: "true"
-        labels:
-          probe: enabled
-        hosts:
-          - host: jelly.kubi.${DOMAIN_LOCAL}
-            paths:
-              - path: /
-                pathType: Prefix
-      public:
-        enabled: true
-        annotations:
-          hajimari.io/enable: "false"
-          traefik.ingress.kubernetes.io/router.entrypoints: webpublic
-          traefik.ingress.kubernetes.io/router.tls: "true"
-        labels:
-          probe: enabled
-        hosts:
-          - host: play.${DOMAIN_PUBLIC}
-            paths:
-              - path: /
-                pathType: Prefix
-    persistence:
-      config:
-        enabled: true
-        storageClass: longhorn
-        size: 10Gi
-        retain: true
-      media:
-        enabled: true
-        type: nfs
-        path: /tank/Media
-        server: nas
-        subPath:
-          - path: Shows/Complete
-            mountPath: /mnt/tv
-          - path: Movies/Complete
-            mountPath: /mnt/movies
-      certificate:
-        enabled: true
-        type: secret
-        name: letsencrypt-jellyfin
-        mountPath: /etc/ssl/private
-        readOnly: true
-      cache:
-        enabled: true
-        type: emptyDir
-        mountPath: /cache
-    resources:
-      limits:
-        gpu.intel.com/i915: 1
-        memory: 6Gi
-      requests:
-        memory: 2Gi
-        cpu: 1

--- a/kubernetes/home/apps/media/jellyfin/release.yaml
+++ b/kubernetes/home/apps/media/jellyfin/release.yaml
@@ -61,6 +61,7 @@ spec:
               capabilities:
                 drop:
                   - ALL
+              readOnlyRootFilesystem: true
 
     ingress:
       main:
@@ -120,6 +121,10 @@ spec:
       cache:
         enabled: true
         mountPath: /cache
+        type: emptyDir
+      tmp:
+        enabled: true
+        mountPath: /tmp
         type: emptyDir
 
     service:

--- a/kubernetes/home/apps/media/jellyfin/release.yaml
+++ b/kubernetes/home/apps/media/jellyfin/release.yaml
@@ -19,6 +19,10 @@ spec:
     env: {}  # Necessary for the generic TZ patch to not fail
     controllers:
       main:
+        pod:
+          securityContext:
+            fsGroup: 997
+            fsGroupChangePolicy: "OnRootMismatch"
         containers:
           main:
             env:
@@ -62,6 +66,9 @@ spec:
                 drop:
                   - ALL
               readOnlyRootFilesystem: true
+              runAsGroup: 997
+              runAsNonRoot: true
+              runAsUser: 942
 
     ingress:
       main:

--- a/kubernetes/home/apps/media/radarr/release.yaml
+++ b/kubernetes/home/apps/media/radarr/release.yaml
@@ -13,69 +13,93 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-      version: 1.5.0 # {"$imagepolicy": "flux-system:app-template:tag"}
+      version: 2.0.3 # {"$imagepolicy": "flux-system:app-template:tag"}
   values:
-    image:
-      repository: docker.io/spritsail/radarr
-      tag: "5.0.3" # {"$imagepolicy": "flux-system:radarr:tag"}
-      pullPolicy: IfNotPresent
-    env:
-      ANALYTICS: "false"
-      SGID: 568
-      SUID: 568
-    probes:
-      liveness:
-        custom: true
-        spec:
-          exec:
-            command:
-              - /bin/sh
-              - '-c'
-              - 'wget -qO /dev/null http://localhost:7878/api/v3/system/status?apiKey=`xmlstarlet sel -t -v /Config/ApiKey /config/config.xml`'
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
-    securityContext:
-      capabilities:
-        drop:
-          - ALL
-        add:
-          - SETUID
-          - SETGID
-    service:
+    env: {} # Necessary for the generic TZ patch to not fail
+    controllers:
       main:
-        ports:
-          http:
-            port: 7878
+        pod:
+          securityContext:
+            fsGroup: 997
+            fsGroupChangePolicy: "OnRootMismatch"
+        containers:
+          main:
+            env:
+              ANALYTICS: "false"
+              SGID: 997
+              TZ: ${TZ}
+            image:
+              repository: docker.io/spritsail/radarr
+              tag: "5.0.3" # {"$imagepolicy": "flux-system:radarr:tag"}
+              pullPolicy: IfNotPresent
+            nameOverride: radarr
+            ports:
+              - containerPort: 7878
+                name: http
+                protocol: TCP
+            probes:
+              liveness:
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - /bin/sh
+                      - '-c'
+                      - 'wget -qO /dev/null http://localhost:7878/api/v3/system/status?apiKey=`xmlstarlet sel -t -v /Config/ApiKey /config/config.xml`'
+                  initialDelaySeconds: 60
+                  timeoutSeconds: 5
+            resources:
+              limits:
+                memory: 512Mi
+              requests:
+                memory: 256Mi
+                cpu: 10m
+            securityContext:
+              capabilities:
+                drop:
+                  - ALL
+                add:
+                  - SETUID
+                  - SETGID
+              readOnlyRootFilesystem: true
+
     ingress:
       main:
-        enabled: true
         annotations:
           hajimari.io/icon: mdi:movie
           traefik.ingress.kubernetes.io/router.entrypoints: websecure
           traefik.ingress.kubernetes.io/router.tls: "true"
-        labels:
-          probe: enabled
+        enabled: true
         hosts:
           - host: radarr.kubi.${DOMAIN_LOCAL}
             paths:
               - path: /
                 pathType: Prefix
+                service:
+                  name: main
+        labels:
+          probe: enabled
+
     persistence:
       config:
         enabled: true
         mountPath: /config
-        storageClass: longhorn
-        size: 1Gi
         retain: true
+        size: 1Gi
+        storageClass: longhorn
       media:
         enabled: true
-        type: nfs
+        mountPath: /media
         path: /tank/Media/Movies
         server: nas
-        mountPath: /media
-    resources:
-      limits:
-        memory: 512Mi
-      requests:
-        memory: 256Mi
-        cpu: 10m
+        type: nfs
+      tmp:
+        enabled: true
+        mountPath: /tmp
+        type: emptyDir
+
+    service:
+      main:
+        ports:
+          http:
+            port: 7878

--- a/kubernetes/home/apps/media/rtorrent/release.yaml
+++ b/kubernetes/home/apps/media/rtorrent/release.yaml
@@ -63,6 +63,10 @@ spec:
 
     controllers:
       main:
+        pod:
+          securityContext:
+            fsGroup: 997
+            fsGroupChangePolicy: "OnRootMismatch"
         containers:
           main:
             env:
@@ -95,6 +99,9 @@ spec:
                 drop:
                   - ALL
               readOnlyRootFilesystem: true
+              runAsGroup: 997
+              runAsNonRoot: true
+              runAsUser: 1001
         initContainers:
           remove-session-lock:
             command:

--- a/kubernetes/home/apps/media/rtorrent/release.yaml
+++ b/kubernetes/home/apps/media/rtorrent/release.yaml
@@ -102,21 +102,6 @@ spec:
               runAsGroup: 997
               runAsNonRoot: true
               runAsUser: 1001
-        initContainers:
-          remove-session-lock:
-            command:
-              - sh
-              - '-c'
-            args:
-              - 'rm -rf /config/.local/share/rtorrent/.session/rtorrent.lock && chown -vR 1001:1001 /config'
-            image:
-              repository: docker.io/busybox
-              tag: latest
-            securityContext:
-              runAsUser: 0
-            volumeMounts:
-              - mountPath: /config
-                name: config
 
     ingress:
       main:

--- a/kubernetes/home/apps/media/rtorrent/release.yaml
+++ b/kubernetes/home/apps/media/rtorrent/release.yaml
@@ -13,18 +13,9 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-      version: 1.5.0 # {"$imagepolicy": "flux-system:app-template:tag"}
+      version: 2.0.3 # {"$imagepolicy": "flux-system:app-template:tag"}
   values:
-    image:
-      repository: docker.io/jesec/rtorrent-flood
-      tag: master-distroless
-      pullPolicy: IfNotPresent
-    env:
-      FLOOD_OPTION_ALLOWEDPATH: "/downloads"
-      FLOOD_OPTION_HOST: "0.0.0.0"
-      FLOOD_OPTION_PORT: "3000"
-      FLOOD_OPTION_RTORRENT: "true"
-      HOME: "/config"
+    env: {} # Necessary for the generic TZ patch to not fail
     configMaps:
       config:
         enabled: true
@@ -69,113 +60,177 @@ spec:
             print = (cat, "Logging to ", (cfg.logfile))
             log.open_file = "log", (cfg.logfile)
             log.add_output = "info", "log"
-    initContainers:
-      remove-session-lock:
-        command:
-          - sh
-          - '-c'
-        args:
-          - 'rm -rf /config/.local/share/rtorrent/.session/rtorrent.lock && chown -vR 1001:1001 /config'
-        image: busybox
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-          - mountPath: /config
-            name: config
-    securityContext:
-      capabilities:
-        drop:
-          - ALL
-      readOnlyRootFilesystem: true
+
+    controllers:
+      main:
+        containers:
+          main:
+            env:
+              FLOOD_OPTION_ALLOWEDPATH: "/downloads"
+              FLOOD_OPTION_HOST: "0.0.0.0"
+              FLOOD_OPTION_PORT: "3000"
+              FLOOD_OPTION_RTORRENT: "true"
+              HOME: "/config"
+              TZ: ${TZ}
+            image:
+              repository: docker.io/jesec/rtorrent-flood
+              tag: master-distroless
+              pullPolicy: IfNotPresent
+            nameOverride: rtorrent-flood
+            ports:
+              - containerPort: 15329
+                name: bittorrent
+                protocol: TCP
+              - containerPort: 3000
+                name: http
+                protocol: TCP
+            resources:
+              limits:
+                memory: 5Gi
+              requests:
+                memory: 4Gi
+                cpu: 50m
+            securityContext:
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+        initContainers:
+          remove-session-lock:
+            command:
+              - sh
+              - '-c'
+            args:
+              - 'rm -rf /config/.local/share/rtorrent/.session/rtorrent.lock && chown -vR 1001:1001 /config'
+            image:
+              repository: docker.io/busybox
+              tag: latest
+            securityContext:
+              runAsUser: 0
+            volumeMounts:
+              - mountPath: /config
+                name: config
+
+    ingress:
+      main:
+        annotations:
+          hajimari.io/icon: mdi:download-network
+          hajimari.io/appName: rTorrent
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+          traefik.ingress.kubernetes.io/router.tls: "true"
+        enabled: true
+        hosts:
+          - host: torrent.kubi.${DOMAIN_LOCAL}
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  name: main
+        labels:
+          probe: enabled
+
+    persistence:
+      config:
+        enabled: true
+        mountPath: /config
+        retain: true
+        size: 1Gi
+        storageClass: longhorn
+      rtorrent-flood-config:
+        advancedMounts:
+          main:
+            main:
+              - path: /config/.rtorrent.rc
+                subPath: .rtorrent.rc
+        enabled: true
+        globalMounts: []
+        name: rtorrent-flood-config
+        type: configMap
+      downloads:
+        advancedMounts:
+          main:
+            main:
+              - path: /downloads/complete
+        enabled: true
+        globalMounts: []
+        path: /tank/Downloads/Complete
+        server: nas
+        type: nfs
+      ebook:
+        advancedMounts:
+          main:
+            main:
+              - path: /downloads/ebook
+        enabled: true
+        globalMounts: []
+        path: /tank/Downloads/Ebook
+        server: nas
+        type: nfs
+      games:
+        advancedMounts:
+          main:
+            main:
+              - path: /downloads/games
+        enabled: true
+        globalMounts: []
+        path: /tank/Downloads/Games
+        server: nas
+        type: nfs
+      program:
+        advancedMounts:
+          main:
+            main:
+              - path: /downloads/program
+        enabled: true
+        globalMounts: []
+        path: /tank/Downloads/Program
+        server: nas
+        type: nfs
+      movies:
+        advancedMounts:
+          main:
+            main:
+              - path: /downloads/movies
+        enabled: true
+        globalMounts: []
+        path: /tank/Media/Movies/Downloads
+        server: nas
+        type: nfs
+      shows:
+        advancedMounts:
+          main:
+            main:
+              - path: /downloads/shows
+        enabled: true
+        globalMounts: []
+        path: /tank/Media/Shows/Downloads
+        server: nas
+        type: nfs
+      music:
+        advancedMounts:
+          main:
+            main:
+              - path: /downloads/music
+        enabled: true
+        globalMounts: []
+        path: /tank/Media/Music/Downloads
+        server: nas
+        type: nfs
+
     service:
       main:
         ports:
           http:
             port: 3000
       bittorrent:
+        annotations:
+          metallb.universe.tf/allow-shared-ip: "metallb-shared-ip"
+        controller: main
         enabled: true
+        externalIPs:
+          - ${METALLB_ADDRESS}
         ports:
           bittorrent:
             port: 15329
             targetPort: 15329
-        annotations:
-          metallb.universe.tf/allow-shared-ip: "metallb-shared-ip"
         type: LoadBalancer
-        externalIPs:
-          - ${METALLB_ADDRESS}
-    ingress:
-      main:
-        enabled: true
-        annotations:
-          hajimari.io/icon: mdi:download-network
-          hajimari.io/appName: rTorrent
-          traefik.ingress.kubernetes.io/router.entrypoints: websecure
-          traefik.ingress.kubernetes.io/router.tls: "true"
-        labels:
-          probe: enabled
-        hosts:
-          - host: torrent.kubi.${DOMAIN_LOCAL}
-            paths:
-              - path: /
-                pathType: Prefix
-    persistence:
-      config:
-        enabled: true
-        mountPath: /config
-        storageClass: longhorn
-        size: 1Gi
-        retain: true
-      rtorrent-flood-config:
-        enabled: true
-        type: configMap
-        mountPath: /config/.rtorrent.rc
-        subPath: .rtorrent.rc
-        name: rtorrent-flood-config
-      downloads:
-        enabled: true
-        type: nfs
-        server: nas
-        path: /tank/Downloads/Complete
-        mountPath: /downloads/complete
-      ebook:
-        enabled: true
-        type: nfs
-        server: nas
-        path: /tank/Downloads/Ebook
-        mountPath: /downloads/ebook
-      games:
-        enabled: true
-        type: nfs
-        server: nas
-        path: /tank/Downloads/Games
-        mountPath: /downloads/games
-      program:
-        enabled: true
-        type: nfs
-        server: nas
-        path: /tank/Downloads/Program
-        mountPath: /downloads/program
-      movies:
-        enabled: true
-        type: nfs
-        server: nas
-        path: /tank/Media/Movies/Downloads
-        mountPath: /downloads/movies
-      shows:
-        enabled: true
-        type: nfs
-        server: nas
-        path: /tank/Media/Shows/Downloads
-        mountPath: /downloads/shows
-      music:
-        enabled: true
-        type: nfs
-        server: nas
-        path: /tank/Media/Music/Downloads
-        mountPath: /downloads/music
-    resources:
-      limits:
-        memory: 5Gi
-      requests:
-        memory: 4Gi
-        cpu: 50m

--- a/kubernetes/home/base/init-entrypoint.sh
+++ b/kubernetes/home/base/init-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Script that checks if the provided config folder is wriable by the specified
+# user and group. If it is not it will change the owner and group for the.
+# Additionally it will remove files specified in `CFG_PRUNE`.
+# Based on: https://github.com/spritsail/sonarr/blob/master/entrypoint.sh
+#
+# Configuration:
+# Config folder path: CFG_DIR (default: /config)
+# User ID: SUID
+# Group ID: SGID
+# Files to remove: $CFG_PRUNE
+set -e
+
+export CFG_DIR="${CFG_DIG:-/config}"
+
+if ! su-exec -e touch "$CFG_DIR/.write-test"; then
+    2>&1 echo "Warning: No permission to write in '$CFG_DIR' directory."
+    2>&1 echo "         Correcting permissions to prevent a crash"
+    2>&1 echo
+    (
+    set -x
+    chown $SUID:$SGID "$CFG_DIR"
+    chmod o+rw "$CFG_DIR"
+    )
+fi
+# Remove temporary file
+rm -f "$CFG_DIR/.write-test"
+
+if printenv CFG_PRUNE >/dev/null; then
+    for elem in $CFG_PRUNE; do
+      2>&1 echo "Removing '$elem' from '$CFG_DIR' directory"
+      rm -rf "${CFG_DIR:?}/${elem:?}"
+    done
+    2>&1 echo
+fi


### PR DESCRIPTION
Update the app-template chart to 2.0.3 for releases in the media namespace:
* jackett
* jellyfin
* radarr
* rtorrent-flood

Add a universal init script to be used as an init container where permissions need to be set on the config volume.